### PR TITLE
 XML update: small batch of fixes + deletion of FastRam_16.txt + changes from DarkGlobe

### DIFF
--- a/settings/Control_Port0_Mouse.txt
+++ b/settings/Control_Port0_Mouse.txt
@@ -147,6 +147,14 @@ Dragonstone
 DragonstoneCD32
 DragonTiles
 DragonTilesAGA
+DrakkhenFiles
+DrakkhenImage
+DrakkhenFilesDe
+DrakkhenImageDe
+DrakkhenFilesFr
+DrakkhenImageFr
+DrakkhenFilesNTSC
+DrakkhenImageNTSC
 DreamWeb
 DreamWebAGA
 DreamWebAGADe

--- a/settings/Memory_FastRam_16.txt
+++ b/settings/Memory_FastRam_16.txt
@@ -1,1 +1,0 @@
-Goblins3

--- a/settings/Screen_Height_200.txt
+++ b/settings/Screen_Height_200.txt
@@ -180,6 +180,12 @@ DogsOfWar
 DonaldDucksPlayground
 DoubleDragon
 DragonsBreath
+DrakkhenFiles
+DrakkhenImage
+DrakkhenFilesDe
+DrakkhenImageDe
+DrakkhenFilesFr
+DrakkhenImageFr
 DreamWeb
 DreamWebAGA
 DreamWebAGADe
@@ -349,8 +355,6 @@ Kristal
 Kult
 LaserSquad
 LastDuel
-LastNinja2
-LastNinja3
 Leander
 Leatherneck
 LegendMindscape
@@ -417,6 +421,10 @@ Might&Magic2
 MiniGolfPlus
 Moebius
 MonkeyIsland2
+MonkeyIsland2De
+MonkeyIsland2Es
+MonkeyIsland2Fr
+MonkeyIsland2It
 MoonShineRacers
 Moonstone
 Motorhead
@@ -436,7 +444,6 @@ NewZealandStoryDemo
 Nicky2
 NickyBoom
 NightHawkF117A
-NinjaRemix
 NinjaWarriors
 NipponSafesInc
 Nitro
@@ -503,6 +510,10 @@ RType2
 SabreTeam
 SabreTeamAGA
 SecretOfMonkeyIsland
+SecretOfMonkeyIslandDe
+SecretOfMonkeyIslandEs
+SecretOfMonkeyIslandFr
+SecretOfMonkeyIslandIt
 Settlers
 Shadowgate
 Shadowlands

--- a/settings/Screen_Height_216.txt
+++ b/settings/Screen_Height_216.txt
@@ -61,6 +61,8 @@ JungleStrikeCD32
 JurassicPark
 JurassicParkAGA
 KidGloves
+LastNinja2
+LastNinja3
 LegendOfTheSword
 Lemmings21MB
 Lemmings2512KB
@@ -101,7 +103,6 @@ RickDangerous25
 RoboCop3
 Rockford
 RuffNTumble
-SecretOfMonkeyIsland
 Sleepwalker
 SmashTV
 Soldier2000
@@ -125,8 +126,6 @@ TowerOfSouls
 TowerOfSoulsAGA
 TrapsNTreasures
 Troddlers
-Turrican
-Turrican2
 TyphoonThompson
 UniversalWarrior
 UniverseCD32

--- a/settings/Screen_Height_240.txt
+++ b/settings/Screen_Height_240.txt
@@ -112,6 +112,7 @@ Nebulus2
 NewYorkWarriors1MB
 NewYorkWarriors512KB
 NightbreedAction
+NinjaRemix
 Oath
 P47Thunderbolt
 Pang
@@ -152,7 +153,10 @@ Toki
 Trolls
 TubularWorlds
 TubularWorldsECS
-Turrican3
+Turrican
+TurricanDemo
+Turrican2
+Turrican2Demo
 Untouchables
 Vixen
 WalkerDecrunched

--- a/settings/Screen_Height_256.txt
+++ b/settings/Screen_Height_256.txt
@@ -94,6 +94,8 @@ TanksFurry
 TennisChamps
 TinyTroops
 TipOff
+Turrican3
+Turrican3Demo
 Ugh
 Vyrus
 WheelsOnFire


### PR DESCRIPTION
Small update. highlight: deletion of FastRam_16.txt. Makes no sense as you suggested. It simply is incorrect given real Amiga H/W supported up to 8MB of FastRAM. 