### PR TITLE
XML update: add Z3 to Speedball2 (CD32)

### DIFF
--- a/settings/Memory_Z3Ram_16.txt
+++ b/settings/Memory_Z3Ram_16.txt
@@ -21,6 +21,7 @@ RiseOftheRobots
 Settlers
 SettlersFr
 SoccerKidAGA
+Speedball2CD32
 SuperSkidmarksCD32
 SuperSkidmarksLowMemCD32
 UFOEnemyUnknownAGA


### PR DESCRIPTION
Based on user feedback ([here](https://retropie.org.uk/forum/topic/30721/speedball-2-cd32-dos-error-103-not-enough-memory/6?_=1623410302653)) additional Z3 required to be able to run Speedball2 (CD32) lha package without issue. Tested on Amiberry 3.3.